### PR TITLE
Use resource as bucket to create terraform dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket" "this" {
 }
 
 resource "aws_s3_bucket_policy" "this" {
-  bucket = "${local.s3_bucket_name}"
+  bucket = "${aws_s3_bucket.this.id}"
   policy = "${data.aws_iam_policy_document.s3_bucket.json}"
 }
 


### PR DESCRIPTION
This will make terraform create the s3 bucket before attaching the policy to the bucket.

Otherwise, potentially user of this module might bump into

```
1 error(s) occurred:
 * module.session_manager_config.aws_s3_bucket_policy.this: 1 error(s) occurred:
 * aws_s3_bucket_policy.this: Error putting S3 policy: NoSuchBucket: The specified bucket does not exist
```