### PR TITLE
Update session_manager policy attached to EC2 instance

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -7,8 +7,34 @@ data "aws_iam_role" "super_admin" {
 }
 
 data "aws_iam_policy_document" "session_manager" {
+  # This policy is mostly copied from arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM version 8
+  # Some statements were removed and specific S3 bucket added to reduce privilege
   statement = {
-    sid    = "AllowConnectToSSMServer"
+    sid    = "AllowSSMActions"
+    effect = "Allow"
+
+    actions = [
+      "ssm:DescribeAssociation",
+      "ssm:DescribeDocument",
+      "ssm:GetDeployablePatchSnapshotForInstance",
+      "ssm:GetDocument",
+      "ssm:GetManifest",
+      "ssm:GetParameters",
+      "ssm:ListAssociations",
+      "ssm:ListInstanceAssociations",
+      "ssm:PutComplianceItems",
+      "ssm:PutConfigurePackageResult",
+      "ssm:PutInventory",
+      "ssm:UpdateAssociationStatus",
+      "ssm:UpdateInstanceAssociationStatus",
+      "ssm:UpdateInstanceInformation",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowEC2Messages"
     effect = "Allow"
 
     actions = [
@@ -18,27 +44,13 @@ data "aws_iam_policy_document" "session_manager" {
       "ec2messages:GetEndpoint",
       "ec2messages:GetMessages",
       "ec2messages:SendReply",
-      "ssm:DescribeAssociation",
-      "ssm:GetDeployablePatchSnapshotForInstance",
-      "ssm:GetDocument",
-      "ssm:DescribeDocument",
-      "ssm:GetManifest",
-      "ssm:GetParameters",
-      "ssm:ListAssociations",
-      "ssm:ListInstanceAssociations",
-      "ssm:PutInventory",
-      "ssm:PutComplianceItems",
-      "ssm:PutConfigurePackageResult",
-      "ssm:UpdateAssociationStatus",
-      "ssm:UpdateInstanceAssociationStatus",
-      "ssm:UpdateInstanceInformation",
     ]
 
     resources = ["*"]
   }
 
   statement = {
-    sid    = "AllowEC2InstancesToConnectToSessionManagerServer"
+    sid    = "AllowSSMMessages"
     effect = "Allow"
 
     actions = [
@@ -48,33 +60,35 @@ data "aws_iam_policy_document" "session_manager" {
       "ssmmessages:OpenDataChannel",
     ]
 
-    resources = [
-      "*",
-    ]
+    resources = ["*"]
   }
 
   statement = {
-    sid    = "AllowEC2InstancesToGetBucketEncryption"
-    effect = "Allow"
-
-    actions = [
-      "s3:GetEncryptionConfiguration",
-    ]
-
-    resources = ["${aws_s3_bucket.this.arn}"]
+    sid       = "AllowCloudWatchPutMetrics"
+    effect    = "Allow"
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
   }
 
   statement = {
-    sid    = "AllowEC2ToStoreLogsToS3Bucket"
+    sid       = "AllowEC2DescribeInstanceStatus"
+    effect    = "Allow"
+    actions   = ["ec2:DescribeInstanceStatus"]
+    resources = ["*"]
+  }
+
+  statement = {
+    sid    = "AllowS3Logging"
     effect = "Allow"
 
     actions = [
-      "s3:PutObject",
-      "s3:GetEncryptionConfiguration",
       "s3:AbortMultipartUpload",
-      "s3:ListMultipartUploadParts",
+      "s3:GetBucketLocation",
+      "s3:GetEncryptionConfiguration",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
 
     resources = [


### PR DESCRIPTION
- Add comment to indicate origin of the policy and to allow future comparison
- Rename statement "AllowConnectToSSMServer" -> "AllowSSMActions"
- Separate ssm: actions into statement "AllowSSMActions" for ease of maintenance
- Separate ec2messages: actions into statement "AllowEC2Messages"
- Add statement "AllowCloudWatchPutMetrics" so SSM agent can create CloudWatch metrics
- Add statement "AllowEC2DescribeInstanceStatus" so SSM agent can examine status of the instance
- Rename statement "AllowEC2InstancesToConnectToSessionManagerServer" -> "AllowSSMMessages"
- Rename statement "AllowEC2ToStoreLogsToS3Bucket" -> "AllowS3Logging"
- Add s3:GetBucketLocation to statement "AllowS3Logging"
- Remove statement "AllowEC2InstancesToGetBucketEncryption" since this permission already present in "AllowS3Logging" statement
- Sort all action alphabetically to simplify comparison with original and other policies