### PR TITLE
Upgrade terraform-aws-session-manager-config module to terraform v0.13 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-session-manager-config
 
-[![Terraform Version](https://img.shields.io/badge/Terraform%20Version->=0.12.0,<0.13.0-blue.svg)](https://releases.hashicorp.com/terraform/)
+[![Terraform Version](https://img.shields.io/badge/Terraform%20Version->=0.13.0,<=0.13.7-blue.svg)](https://releases.hashicorp.com/terraform/)
 [![Release](https://img.shields.io/github/release/traveloka/terraform-aws-session-manager-config.svg)](https://github.com/traveloka/terraform-aws-session-manager-config/releases)
 [![Last Commit](https://img.shields.io/github/last-commit/traveloka/terraform-aws-session-manager-config.svg)](https://github.com/traveloka/terraform-aws-session-manager-config/commits/master)
 [![Issues](https://img.shields.io/github/issues/traveloka/terraform-aws-session-manager-config.svg)](https://github.com/traveloka/terraform-aws-session-manager-config/issues)
@@ -18,7 +18,6 @@ This terraform module creates configuration for session manager preferences or l
 - [Table of Content](#table-of-content)
 - [Dependencies](#dependencies)
 - [Terraform Version](#terraform-version)
-- [Authors](#authors)
 - [Requirements](#requirements)
 - [Providers](#providers)
 - [Modules](#modules)
@@ -26,6 +25,7 @@ This terraform module creates configuration for session manager preferences or l
 - [Inputs](#inputs)
 - [Outputs](#outputs)
 - [Contributing](#contributing)
+- [Authors](#authors)
 - [License](#license)
 
 
@@ -35,11 +35,7 @@ This Terraform module have no dependencies to another modules
 
 
 ## Terraform Version
-This module was created on 03/14/2019. The latest stable version of Terraform which this module tested working is Terraform 0.12.31 on 16/09/2021
-
-
-## Authors
-* [Bernard](https://github.com/SiahaanBernard)
+This module was created on 03/14/2019. The latest stable version of Terraform which this module tested working is Terraform 0.13.7 on 17/09/2021
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -47,7 +43,7 @@ This module was created on 03/14/2019. The latest stable version of Terraform wh
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 1.36.0 |
 
 ## Providers
@@ -101,6 +97,9 @@ No modules.
 ## Contributing
 
 This module accepting or open for any contributions from anyone, please see the [CONTRIBUTING.md](https://github.com/traveloka/terraform-aws-session-manager-config/blob/master/CONTRIBUTING.md) for more detail about how to contribute to this module.
+
+## Authors
+* [Bernard](https://github.com/SiahaanBernard)
 
 ## License
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
-
   required_providers {
-    aws = ">= 1.36.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 1.36.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
…3 compatible

<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-session-manager-config/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Upgrade terraform-aws-session-manager-config module to terraform v0.13 compatible

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
