### PR TITLE
Deprecate s3 bucket logs target

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ No modules.
 | <a name="input_s3_delete_permission_role_name"></a> [s3\_delete\_permission\_role\_name](#input\_s3\_delete\_permission\_role\_name) | AWS IAM role name that given access to delete the s3 bucket/object(s) | `string` | `"SuperAdmin"` | no |
 | <a name="input_s3_enable_expiration"></a> [s3\_enable\_expiration](#input\_s3\_enable\_expiration) | You need to set this variable to true if you want to set s3\_expiration\_days | `bool` | `true` | no |
 | <a name="input_s3_enable_versioning"></a> [s3\_enable\_versioning](#input\_s3\_enable\_versioning) | Enable versioning for this bucket | `string` | `"true"` | no |
-| <a name="input_s3_expiration_days"></a> [s3\_expiration\_days](#input\_s3\_expiration\_days) | Number of days to automate logs removal from s3 bucket | `number` | `90` | no |
+| <a name="input_s3_expiration_days"></a> [s3\_expiration\_days](#input\_s3\_expiration\_days) | Number of days to automate logs removal from s3 bucket | `number` | `1` | no |
 | <a name="input_s3_sse_algorithm"></a> [s3\_sse\_algorithm](#input\_s3\_sse\_algorithm) | Encryption algorithm used for this bucket | `string` | `"AES256"` | no |
 | <a name="input_session_manager_document_name"></a> [session\_manager\_document\_name](#input\_session\_manager\_document\_name) | The name of SSM document for session manager, this default name is the one allowed by AWS | `string` | `"SSM-SessionManagerRunShell"` | no |
 | <a name="input_ssm_document_description"></a> [ssm\_document\_description](#input\_ssm\_document\_description) | description for ssm document | `string` | `"document to hold regional session manager preferences"` | no |

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ This module was created on 03/14/2019. The latest stable version of Terraform wh
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 1.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 1.36.0, <= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 1.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 1.36.0, <= 4.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cwl_logs_retention_days"></a> [cwl\_logs\_retention\_days](#input\_cwl\_logs\_retention\_days) | Retention period for cloudwatch logs | `number` | `120` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | environment where this infrastructure reside. | `string` | n/a | yes |
 | <a name="input_product_domain"></a> [product\_domain](#input\_product\_domain) | product domain who owns this SSM Session Manager Configuration | `string` | n/a | yes |
 | <a name="input_s3_bucket_description"></a> [s3\_bucket\_description](#input\_s3\_bucket\_description) | description for this bucket. | `string` | `"s3 bucket to store SSM session manager logs"` | no |
 | <a name="input_s3_bucket_prefix"></a> [s3\_bucket\_prefix](#input\_s3\_bucket\_prefix) | (Optional) To write output to a sub-dir, enter a sub-dir name. | `string` | `""` | no |
 | <a name="input_s3_delete_permission_role_name"></a> [s3\_delete\_permission\_role\_name](#input\_s3\_delete\_permission\_role\_name) | AWS IAM role name that given access to delete the s3 bucket/object(s) | `string` | `"SuperAdmin"` | no |
-| <a name="input_s3_enable_expiration"></a> [s3\_enable\_expiration](#input\_s3\_enable\_expiration) | You need to set this variable to true if you want to set s3\_expiration\_days | `bool` | `false` | no |
+| <a name="input_s3_enable_expiration"></a> [s3\_enable\_expiration](#input\_s3\_enable\_expiration) | You need to set this variable to true if you want to set s3\_expiration\_days | `bool` | `true` | no |
 | <a name="input_s3_enable_versioning"></a> [s3\_enable\_versioning](#input\_s3\_enable\_versioning) | Enable versioning for this bucket | `string` | `"true"` | no |
-| <a name="input_s3_expiration_days"></a> [s3\_expiration\_days](#input\_s3\_expiration\_days) | Number of days to automate logs removal from s3 bucket | `number` | `365` | no |
+| <a name="input_s3_expiration_days"></a> [s3\_expiration\_days](#input\_s3\_expiration\_days) | Number of days to automate logs removal from s3 bucket | `number` | `90` | no |
 | <a name="input_s3_sse_algorithm"></a> [s3\_sse\_algorithm](#input\_s3\_sse\_algorithm) | Encryption algorithm used for this bucket | `string` | `"AES256"` | no |
 | <a name="input_session_manager_document_name"></a> [session\_manager\_document\_name](#input\_session\_manager\_document\_name) | The name of SSM document for session manager, this default name is the one allowed by AWS | `string` | `"SSM-SessionManagerRunShell"` | no |
 | <a name="input_ssm_document_description"></a> [ssm\_document\_description](#input\_ssm\_document\_description) | description for ssm document | `string` | `"document to hold regional session manager preferences"` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -3,8 +3,7 @@ locals {
   iam_policy_name   = "EC2PolicyToEnableSSM"
   ssm_document_name = "SSM-SessionManagerRunShell"
 
-  cwl_log_group_name      = "/aws/ssm/session-manager"
-  cwl_logs_retention_days = 90
+  cwl_log_group_name = "/aws/ssm/session-manager"
 
   s3_logging_bucket = "default-s3-logs-${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,8 @@ resource "aws_s3_bucket" "this" {
     }
   }
 
+  force_destroy = true
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -57,7 +59,7 @@ resource "aws_s3_bucket_policy" "this" {
 
 resource "aws_cloudwatch_log_group" "this" {
   name              = local.cwl_log_group_name
-  retention_in_days = local.cwl_logs_retention_days
+  retention_in_days = var.cwl_logs_retention_days
 
   tags = {
     ProductDomain = var.product_domain
@@ -86,9 +88,6 @@ resource "aws_ssm_document" "this" {
     "description": "${var.ssm_document_description}",
     "sessionType": "Standard_Stream",
     "inputs": {
-        "s3BucketName": "${local.s3_bucket_name}",
-        "s3KeyPrefix": "${var.s3_bucket_prefix}",
-        "s3EncryptionEnabled": true,
         "cloudWatchLogGroupName": "${local.cwl_log_group_name}",
         "cloudWatchEncryptionEnabled": false,
         "cloudWatchStreamingEnabled": true,

--- a/providers.tf
+++ b/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 1.36.0"
+      version = ">= 1.36.0, <= 4.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,13 +45,13 @@ variable "s3_sse_algorithm" {
 
 variable "s3_expiration_days" {
   description = "Number of days to automate logs removal from s3 bucket"
-  default     = 365
+  default     = 90
   type        = number
 }
 
 variable "s3_enable_expiration" {
   description = "You need to set this variable to true if you want to set s3_expiration_days"
-  default     = false
+  default     = true
   type        = bool
 }
 
@@ -59,4 +59,10 @@ variable "s3_delete_permission_role_name" {
   description = "AWS IAM role name that given access to delete the s3 bucket/object(s)"
   default     = "SuperAdmin"
   type        = string
+}
+
+variable "cwl_logs_retention_days" {
+  description = "Retention period for cloudwatch logs"
+  default     = 120
+  type        = number
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "s3_sse_algorithm" {
 
 variable "s3_expiration_days" {
   description = "Number of days to automate logs removal from s3 bucket"
-  default     = 90
+  default     = 1
   type        = number
 }
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
[ADR 002: Double Write Session Manager Logs](https://29022131.atlassian.net/l/c/1u1Locde)

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-session-manager-config/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

- Update cwl logs default retention period to 120 days
- Prepare s3 bucket for deprecation starting with removing it from session manager target logs storage and setting expiration to more aggressive number.
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
